### PR TITLE
terraform-docs 0.12 parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ View **[Dockerfile](https://github.com/cytopia/docker-terraform-docs/blob/master
 Tiny Alpine-based multistage-build dockerized version of [terraform-docs](https://github.com/segmentio/terraform-docs)<sup>[1]</sup>,
 which additionally implements `terraform-docs-replace` allowing you to automatically and safely
 replace the `terraform-docs` generated output infile.
-Furthermore this implementation is also **Terraform >= 0.12 ready**. See [Generic Usage](#generic) for more details.
+Furthermore this implementation is also **Terraform >= 0.12 ready**<sup>[2]</sup>. See [Generic Usage](#generic) for more details.
 The image is built nightly against multiple stable versions and pushed to Dockerhub.
 
-<sub>[1] Official project: https://github.com/segmentio/terraform-docs</sub>
+* <sub>[1] Official project: https://github.com/segmentio/terraform-docs</sub>
+* <sub>[2] Based on an awk script by [cloudposse/build-harness](https://github.com/cloudposse/build-harness/blob/master/bin/terraform-docs.awk)</sub>
 
 
 ## Available Docker image versions

--- a/data/docker-entrypoint.sh
+++ b/data/docker-entrypoint.sh
@@ -144,7 +144,7 @@ if [ "${#}" -ge "1" ]; then
 	###
 	elif [ "${1}" = "terraform-docs-012" ]; then
 		mkdir -p /tmp-012
-		awk -f /usr/bin/terraform-docs.awk *.tf > "/tmp-012/tmp.tf"
+		awk -f /terraform-docs.awk *.tf > "/tmp-012/tmp.tf"
 
 		# Remove last argument (path)
 		args="$(trim_last_arg "${@}")"	# get all the args except the last arg


### PR DESCRIPTION
# `terraform-docs` 0.12 parsing 

`terraform-docs` 0.12 parsing is done via an awk script provided by awesome [cloudposse/build-harness](https://github.com/cloudposse/build-harness/blob/master/bin/terraform-docs.awk).

It was currently lacking the parsing of multi-line default statements and the fix has been submitted here as well as upstream: https://github.com/cloudposse/build-harness/pull/155