### PR TITLE
Enhance terraform-docs.awk transformation for Terraform 0.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,21 @@ _test_run:
 	@echo "------------------------------------------------------------"
 	@echo "- Testing terraform-docs"
 	@echo "------------------------------------------------------------"
-	@if ! docker run --rm -v $(CURRENT_DIR)/tests/default:/data $(IMAGE) terraform-docs-replace md TEST-$(TAG).md; then \
+	$(eval TFDOC_ARG_SORT = $(shell \
+		if [ "$(TAG)" = "latest" ] || [ "$(TAG)" = "0.6.0" ] || [ "$(TAG)" = "0.5.0" ]; then \
+			echo "--sort-inputs-by-required"; \
+		fi; \
+	))
+	$(eval TFDOC_ARG_AGGREGATE = $(shell \
+		if [ "$(TAG)" = "latest" ] || [ "$(TAG)" = "0.6.0" ] || [ "$(TAG)" = "0.5.0" ] || [ "$(TAG)" = "0.4.5" ] || [ "$(TAG)" = "0.4.0" ]; then \
+			echo "--with-aggregate-type-defaults"; \
+		fi; \
+	))
+	@if ! docker run --rm -v $(CURRENT_DIR)/tests/default:/data $(IMAGE) terraform-docs-replace $(TFDOC_ARG_SORT) $(TFDOC_ARG_AGGREGATE) md TEST-$(TAG).md; then \
 		echo "Failed"; \
 		exit 1; \
 	fi
-	@if ! docker run --rm -v $(CURRENT_DIR)/tests/0.12:/data $(IMAGE) terraform-docs-replace-012 md TEST-$(TAG).md; then \
+	@if ! docker run --rm -v $(CURRENT_DIR)/tests/0.12:/data $(IMAGE) terraform-docs-replace-012 $(TFDOC_ARG_SORT) $(TFDOC_ARG_AGGREGATE) md TEST-$(TAG).md; then \
 		echo "Failed"; \
 		exit 1; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifneq (,)
 .error This Makefile requires GNU Make.
 endif
 
-.PHONY: build rebuild test _test_version _test_run tag pull login push enter
+.PHONY: build rebuild lint test _test_version _test_run tag pull login push enter
 
 CURRENT_DIR = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -16,6 +16,14 @@ build:
 
 rebuild: pull
 	docker build --no-cache --build-arg VERSION=$(TAG) -t $(IMAGE) -f $(DIR)/$(FILE) $(DIR)
+
+lint:
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint file-cr --text --ignore '.git/,.github/,tests/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint file-crlf --text --ignore '.git/,.github/,tests/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint file-trailing-single-newline --text --ignore '.git/,.github/,tests/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint file-trailing-space --text --ignore '.git/,.github/,tests/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint file-utf8 --text --ignore '.git/,.github/,tests/' --path .
+	@docker run --rm -v $(CURRENT_DIR):/data cytopia/file-lint file-utf8-bom --text --ignore '.git/,.github/,tests/' --path .
 
 test:
 	@$(MAKE) --no-print-directory _test_version

--- a/data/docker-entrypoint.sh
+++ b/data/docker-entrypoint.sh
@@ -115,7 +115,7 @@ if [ "${#}" -ge "1" ]; then
 			# Get terraform-docs output
 			>&2 echo "terraform-docs-012 ${*} ${WORKDIR}"
 			if ! DOCS="$(terraform-docs "${@}" "/tmp-012")"; then
-				cat -n /tmp-012/tmp.tf
+				cat -n "/tmp-012/tmp.tf" >&2
 				exit 1
 			fi
 		fi
@@ -153,7 +153,10 @@ if [ "${#}" -ge "1" ]; then
 		# Remove first argument (terraform-docs-012)
 		shift
 		# Execute
-		exec terraform-docs "${@}" "/tmp-012/"
+		if ! terraform-docs "${@}" "/tmp-012/"; then
+			cat -n "/tmp-012/tmp.tf" >&2
+			exit 1
+		fi
 
 	###
 	### Unsupported command

--- a/data/terraform-docs.awk
+++ b/data/terraform-docs.awk
@@ -15,7 +15,7 @@
   }
 
   # [START] variable or output block started
-  if ($0 ~ /^\s*(variable|output)\s+"(.*?)"/) {
+  if ($0 ~ /^[[:space:]]*(variable|output)[[:space:]][[:space:]]*"(.*?)"/) {
     # Normalize the braceCnt (should be 1 now)
     braceCnt = 1
     # [CLOSE] "default" block
@@ -28,17 +28,21 @@
 
   # [START] multiline default statement started
   if (blockCnt > 0) {
-    if ($0 ~ /^\s*default\s*=/) {
-      print $0
-      blockDefCnt++
-      blockDefStart=1
+    if ($0 ~ /^[[:space:]][[:space:]]*(default)[[:space:]][[:space:]]*=/) {
+      if ($3 ~ "null") {
+        print "  default = \"null\""
+      } else {
+        print $0
+        blockDefCnt++
+        blockDefStart=1
+      }
     }
   }
 
   # [PRINT] single line "description"
   if (blockCnt > 0) {
     if (blockDefCnt == 0) {
-      if ($0 ~ /^\s*description\s*=/) {
+      if ($0 ~ /^[[:space:]][[:space:]]*description[[:space:]][[:space:]]*=/) {
         # [CLOSE] "default" block
         if (blockDefCnt > 0) {
           blockDefCnt = 0
@@ -50,7 +54,7 @@
 
   # [PRINT] single line "type"
   if (blockCnt > 0) {
-    if ($0 ~ /^\s*type\s*=/ ) {
+    if ($0 ~ /^[[:space:]][[:space:]]*type[[:space:]][[:space:]]*=/ ) {
       # [CLOSE] "default" block
       if (blockDefCnt > 0) {
         blockDefCnt = 0

--- a/tests/0.12/TEST-0.1.0.md
+++ b/tests/0.12/TEST-0.1.0.md
@@ -8,14 +8,61 @@ Stuff before terraform-docs
 
 | Name | Description | Default | Required |
 |------|-------------|:-----:|:-----:|
+| computed_egress_rules | List of computed egress rules to create by name | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | `<list>` | no |
+| create | Whether to create security group and all rules | `true` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | `<list>` | no |
+| description | Description of security group | `Security Group managed by Terraform` | no |
+| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | `<list>` | no |
+| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | `<list>` | no |
+| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | `<list>` | no |
+| egress_rules | List of egress rules to create by name | `<list>` | no |
+| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | `<list>` | no |
+| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | `<list>` | no |
+| egress_with_self | List of egress rules to create where 'self' is defined | `<list>` | no |
+| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | `<list>` | no |
+| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | `<list>` | no |
+| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | `<list>` | no |
+| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | `<list>` | no |
+| ingress_rules | List of ingress rules to create by name | `<list>` | no |
+| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | `<list>` | no |
+| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | `<list>` | no |
+| ingress_with_self | List of ingress rules to create where 'self' is defined | `<list>` | no |
+| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | `<list>` | no |
+| name | Name of security group | - | yes |
 | network | The network | `<map>` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | `0` | no |
+| tags | A mapping of tags to assign to security group | `<map>` | no |
+| use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | `true` | no |
+| vpc_id | ID of the VPC where to create security group | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment |  |
+| this_security_group_description |  |
+| this_security_group_id |  |
+| this_security_group_name |  |
+| this_security_group_owner_id |  |
+| this_security_group_vpc_id |  |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-0.1.0.md
+++ b/tests/0.12/TEST-0.1.0.md
@@ -8,6 +8,14 @@ Stuff before terraform-docs
 
 | Name | Description | Default | Required |
 |------|-------------|:-----:|:-----:|
+| allocated_storage | The allocated storage in gigabytes | - | yes |
+| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | `false` | no |
+| apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `false` | no |
+| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `true` | no |
+| availability_zone | The Availability Zone of the RDS instance | `` | no |
+| backup_retention_period | The days to retain backups for | `1` | no |
+| backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | - | yes |
+| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | `` | no |
 | computed_egress_rules | List of computed egress rules to create by name | `<list>` | no |
 | computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | `<list>` | no |
 | computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | `<list>` | no |
@@ -18,8 +26,16 @@ Stuff before terraform-docs
 | computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | `<list>` | no |
 | computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | `<list>` | no |
 | computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | `<list>` | no |
+| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | `false` | no |
 | create | Whether to create security group and all rules | `true` | no |
+| create_db_instance | Whether to create a database instance | `true` | no |
+| create_db_option_group | Whether to create a database option group | `true` | no |
+| create_db_parameter_group | Whether to create a database parameter group | `true` | no |
+| create_db_subnet_group | Whether to create a database subnet group | `true` | no |
+| create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `false` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | `<list>` | no |
+| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `` | no |
+| deletion_protection | The database can't be deleted when this value is set to true. | `false` | no |
 | description | Description of security group | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | `<list>` | no |
 | egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | `<list>` | no |
@@ -29,6 +45,13 @@ Stuff before terraform-docs
 | egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | `<list>` | no |
 | egress_with_self | List of egress rules to create where 'self' is defined | `<list>` | no |
 | egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | `<list>` | no |
+| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `<list>` | no |
+| engine | The database engine to use | - | yes |
+| engine_version | The engine version to use | - | yes |
+| family | The family of the DB parameter group | `` | no |
+| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | `null` | no |
+| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `false` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | - | yes |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | `<list>` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | `<list>` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | `<list>` | no |
@@ -37,7 +60,18 @@ Stuff before terraform-docs
 | ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | `<list>` | no |
 | ingress_with_self | List of ingress rules to create where 'self' is defined | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | `<list>` | no |
+| instance_class | The instance type of the RDS instance | - | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | `0` | no |
+| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | `` | no |
+| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | `` | no |
+| maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | - | yes |
+| major_engine_version | Specifies the major version of the engine that this option group should be associated with | `` | no |
+| monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `0` | no |
+| monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | `` | no |
+| monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | `rds-monitoring-role` | no |
+| multi_az | Specifies if the RDS instance is multi-AZ | `false` | no |
 | name | Name of security group | - | yes |
+| name | The DB name to create. If omitted, no database is created initially | `` | no |
 | network | The network | `<map>` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | `0` | no |
@@ -49,15 +83,54 @@ Stuff before terraform-docs
 | number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | `0` | no |
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | `0` | no |
+| option_group_description | The description of the option group | `` | no |
+| option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | `` | no |
+| options | A list of Options to apply. | `<list>` | no |
+| parameter_group_description | Description of the DB parameter group to create | `` | no |
+| parameter_group_name | Name of the DB parameter group to associate or create | `` | no |
+| parameters | A list of DB parameters (map) to apply | `<list>` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | - | yes |
+| port | The port on which the DB accepts connections | - | yes |
+| publicly_accessible | Bool to control if instance is publicly accessible | `false` | no |
+| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `` | no |
+| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | `true` | no |
+| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `` | no |
+| storage_encrypted | Specifies whether the DB instance is encrypted | `false` | no |
+| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | `gp2` | no |
+| subnet_ids | A list of VPC subnet IDs | `<list>` | no |
 | tags | A mapping of tags to assign to security group | `<map>` | no |
+| tags | A mapping of tags to assign to all resources | `<map>` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `<map>` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | `true` | no |
+| use_parameter_group_name_prefix | Whether to use the parameter group name prefix or not | `true` | no |
+| username | Username for the master DB user | - | yes |
 | vpc_id | ID of the VPC where to create security group | - | yes |
+| vpc_security_group_ids | List of VPC security groups to associate | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment |  |
+| this_db_instance_address |  |
+| this_db_instance_arn |  |
+| this_db_instance_availability_zone |  |
+| this_db_instance_endpoint |  |
+| this_db_instance_hosted_zone_id |  |
+| this_db_instance_id |  |
+| this_db_instance_name |  |
+| this_db_instance_password |  |
+| this_db_instance_port |  |
+| this_db_instance_resource_id |  |
+| this_db_instance_status |  |
+| this_db_instance_username |  |
+| this_db_option_group_arn |  |
+| this_db_option_group_id |  |
+| this_db_parameter_group_arn |  |
+| this_db_parameter_group_id |  |
+| this_db_subnet_group_arn |  |
+| this_db_subnet_group_id |  |
 | this_security_group_description |  |
 | this_security_group_id |  |
 | this_security_group_name |  |

--- a/tests/0.12/TEST-0.1.1.md
+++ b/tests/0.12/TEST-0.1.1.md
@@ -8,14 +8,61 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| create | Whether to create security group and all rules | bool | `true` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| description | Description of security group | string | `Security Group managed by Terraform` | no |
+| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
+| egress_rules | List of egress rules to create by name | list(string) | `<list>` | no |
+| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
+| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | number | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| vpc_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_security_group_description | The description of the security group |
+| this_security_group_id | The ID of the security group |
+| this_security_group_name | The name of the security group |
+| this_security_group_owner_id | The owner ID |
+| this_security_group_vpc_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-0.1.1.md
+++ b/tests/0.12/TEST-0.1.1.md
@@ -8,6 +8,14 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated_storage | The allocated storage in gigabytes | string | - | yes |
+| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | bool | `false` | no |
+| apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
+| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `true` | no |
+| availability_zone | The Availability Zone of the RDS instance | string | `` | no |
+| backup_retention_period | The days to retain backups for | number | `1` | no |
+| backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
+| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
 | computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
 | computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
@@ -18,8 +26,16 @@ Stuff before terraform-docs
 | computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `false` | no |
 | create | Whether to create security group and all rules | bool | `true` | no |
+| create_db_instance | Whether to create a database instance | bool | `true` | no |
+| create_db_option_group | Whether to create a database option group | bool | `true` | no |
+| create_db_parameter_group | Whether to create a database parameter group | bool | `true` | no |
+| create_db_subnet_group | Whether to create a database subnet group | bool | `true` | no |
+| create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `false` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
+| deletion_protection | The database can't be deleted when this value is set to true. | bool | `false` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
 | egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
@@ -29,6 +45,13 @@ Stuff before terraform-docs
 | egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list(string) | `<list>` | no |
+| engine | The database engine to use | string | - | yes |
+| engine_version | The engine version to use | string | - | yes |
+| family | The family of the DB parameter group | string | `` | no |
+| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
+| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
@@ -37,7 +60,18 @@ Stuff before terraform-docs
 | ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| instance_class | The instance type of the RDS instance | string | - | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `0` | no |
+| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
+| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
+| maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
+| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
+| monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | number | `0` | no |
+| monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
+| monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
+| multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
 | name | Name of security group | string | - | yes |
+| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
 | network | The network | object | `<map>` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -49,15 +83,54 @@ Stuff before terraform-docs
 | number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| option_group_description | The description of the option group | string | `` | no |
+| option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
+| options | A list of Options to apply. | any | `<list>` | no |
+| parameter_group_description | Description of the DB parameter group to create | string | `` | no |
+| parameter_group_name | Name of the DB parameter group to associate or create | string | `` | no |
+| parameters | A list of DB parameters (map) to apply | list(map(string)) | `<list>` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
+| port | The port on which the DB accepts connections | string | - | yes |
+| publicly_accessible | Bool to control if instance is publicly accessible | bool | `false` | no |
+| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
+| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `true` | no |
+| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
+| storage_encrypted | Specifies whether the DB instance is encrypted | bool | `false` | no |
+| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
+| subnet_ids | A list of VPC subnet IDs | list(string) | `<list>` | no |
 | tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| tags | A mapping of tags to assign to all resources | map(string) | `<map>` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `<map>` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| use_parameter_group_name_prefix | Whether to use the parameter group name prefix or not | bool | `true` | no |
+| username | Username for the master DB user | string | - | yes |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
+| vpc_security_group_ids | List of VPC security groups to associate | list(string) | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_db_instance_address | The address of the RDS instance |
+| this_db_instance_arn | The ARN of the RDS instance |
+| this_db_instance_availability_zone | The availability zone of the RDS instance |
+| this_db_instance_endpoint | The connection endpoint |
+| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this_db_instance_id | The RDS instance ID |
+| this_db_instance_name | The database name |
+| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this_db_instance_port | The database port |
+| this_db_instance_resource_id | The RDS Resource ID of this instance |
+| this_db_instance_status | The RDS instance status |
+| this_db_instance_username | The master username for the database |
+| this_db_option_group_arn | The ARN of the db option group |
+| this_db_option_group_id | The db option group id |
+| this_db_parameter_group_arn | The ARN of the db parameter group |
+| this_db_parameter_group_id | The db parameter group id |
+| this_db_subnet_group_arn | The ARN of the db subnet group |
+| this_db_subnet_group_id | The db subnet group name |
 | this_security_group_description | The description of the security group |
 | this_security_group_id | The ID of the security group |
 | this_security_group_name | The name of the security group |

--- a/tests/0.12/TEST-0.2.0.md
+++ b/tests/0.12/TEST-0.2.0.md
@@ -8,14 +8,61 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| create | Whether to create security group and all rules | bool | `true` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| description | Description of security group | string | `Security Group managed by Terraform` | no |
+| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
+| egress_rules | List of egress rules to create by name | list(string) | `<list>` | no |
+| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
+| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | number | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| vpc_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_security_group_description | The description of the security group |
+| this_security_group_id | The ID of the security group |
+| this_security_group_name | The name of the security group |
+| this_security_group_owner_id | The owner ID |
+| this_security_group_vpc_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-0.2.0.md
+++ b/tests/0.12/TEST-0.2.0.md
@@ -8,6 +8,14 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated_storage | The allocated storage in gigabytes | string | - | yes |
+| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | bool | `false` | no |
+| apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
+| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `true` | no |
+| availability_zone | The Availability Zone of the RDS instance | string | `` | no |
+| backup_retention_period | The days to retain backups for | number | `1` | no |
+| backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
+| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
 | computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
 | computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
@@ -18,8 +26,16 @@ Stuff before terraform-docs
 | computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `false` | no |
 | create | Whether to create security group and all rules | bool | `true` | no |
+| create_db_instance | Whether to create a database instance | bool | `true` | no |
+| create_db_option_group | Whether to create a database option group | bool | `true` | no |
+| create_db_parameter_group | Whether to create a database parameter group | bool | `true` | no |
+| create_db_subnet_group | Whether to create a database subnet group | bool | `true` | no |
+| create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `false` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
+| deletion_protection | The database can't be deleted when this value is set to true. | bool | `false` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
 | egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
@@ -29,6 +45,13 @@ Stuff before terraform-docs
 | egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list(string) | `<list>` | no |
+| engine | The database engine to use | string | - | yes |
+| engine_version | The engine version to use | string | - | yes |
+| family | The family of the DB parameter group | string | `` | no |
+| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
+| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
@@ -37,7 +60,18 @@ Stuff before terraform-docs
 | ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| instance_class | The instance type of the RDS instance | string | - | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `0` | no |
+| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
+| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
+| maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
+| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
+| monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | number | `0` | no |
+| monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
+| monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
+| multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
 | name | Name of security group | string | - | yes |
+| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
 | network | The network | object | `<map>` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -49,15 +83,54 @@ Stuff before terraform-docs
 | number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| option_group_description | The description of the option group | string | `` | no |
+| option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
+| options | A list of Options to apply. | any | `<list>` | no |
+| parameter_group_description | Description of the DB parameter group to create | string | `` | no |
+| parameter_group_name | Name of the DB parameter group to associate or create | string | `` | no |
+| parameters | A list of DB parameters (map) to apply | list(map(string)) | `<list>` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
+| port | The port on which the DB accepts connections | string | - | yes |
+| publicly_accessible | Bool to control if instance is publicly accessible | bool | `false` | no |
+| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
+| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `true` | no |
+| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
+| storage_encrypted | Specifies whether the DB instance is encrypted | bool | `false` | no |
+| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
+| subnet_ids | A list of VPC subnet IDs | list(string) | `<list>` | no |
 | tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| tags | A mapping of tags to assign to all resources | map(string) | `<map>` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `<map>` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| use_parameter_group_name_prefix | Whether to use the parameter group name prefix or not | bool | `true` | no |
+| username | Username for the master DB user | string | - | yes |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
+| vpc_security_group_ids | List of VPC security groups to associate | list(string) | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_db_instance_address | The address of the RDS instance |
+| this_db_instance_arn | The ARN of the RDS instance |
+| this_db_instance_availability_zone | The availability zone of the RDS instance |
+| this_db_instance_endpoint | The connection endpoint |
+| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this_db_instance_id | The RDS instance ID |
+| this_db_instance_name | The database name |
+| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this_db_instance_port | The database port |
+| this_db_instance_resource_id | The RDS Resource ID of this instance |
+| this_db_instance_status | The RDS instance status |
+| this_db_instance_username | The master username for the database |
+| this_db_option_group_arn | The ARN of the db option group |
+| this_db_option_group_id | The db option group id |
+| this_db_parameter_group_arn | The ARN of the db parameter group |
+| this_db_parameter_group_id | The db parameter group id |
+| this_db_subnet_group_arn | The ARN of the db subnet group |
+| this_db_subnet_group_id | The db subnet group name |
 | this_security_group_description | The description of the security group |
 | this_security_group_id | The ID of the security group |
 | this_security_group_name | The name of the security group |

--- a/tests/0.12/TEST-0.3.0.md
+++ b/tests/0.12/TEST-0.3.0.md
@@ -8,14 +8,61 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| create | Whether to create security group and all rules | bool | `true` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| description | Description of security group | string | `Security Group managed by Terraform` | no |
+| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
+| egress_rules | List of egress rules to create by name | list(string) | `<list>` | no |
+| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
+| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | number | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| vpc_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_security_group_description | The description of the security group |
+| this_security_group_id | The ID of the security group |
+| this_security_group_name | The name of the security group |
+| this_security_group_owner_id | The owner ID |
+| this_security_group_vpc_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-0.3.0.md
+++ b/tests/0.12/TEST-0.3.0.md
@@ -8,6 +8,14 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated_storage | The allocated storage in gigabytes | string | - | yes |
+| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | bool | `false` | no |
+| apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
+| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `true` | no |
+| availability_zone | The Availability Zone of the RDS instance | string | `` | no |
+| backup_retention_period | The days to retain backups for | number | `1` | no |
+| backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
+| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
 | computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
 | computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
@@ -18,8 +26,16 @@ Stuff before terraform-docs
 | computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `false` | no |
 | create | Whether to create security group and all rules | bool | `true` | no |
+| create_db_instance | Whether to create a database instance | bool | `true` | no |
+| create_db_option_group | Whether to create a database option group | bool | `true` | no |
+| create_db_parameter_group | Whether to create a database parameter group | bool | `true` | no |
+| create_db_subnet_group | Whether to create a database subnet group | bool | `true` | no |
+| create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `false` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
+| deletion_protection | The database can't be deleted when this value is set to true. | bool | `false` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
 | egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
@@ -29,6 +45,13 @@ Stuff before terraform-docs
 | egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list(string) | `<list>` | no |
+| engine | The database engine to use | string | - | yes |
+| engine_version | The engine version to use | string | - | yes |
+| family | The family of the DB parameter group | string | `` | no |
+| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
+| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
@@ -37,7 +60,18 @@ Stuff before terraform-docs
 | ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
 | ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| instance_class | The instance type of the RDS instance | string | - | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `0` | no |
+| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
+| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
+| maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
+| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
+| monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | number | `0` | no |
+| monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
+| monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
+| multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
 | name | Name of security group | string | - | yes |
+| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
 | network | The network | object | `<map>` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -49,15 +83,54 @@ Stuff before terraform-docs
 | number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| option_group_description | The description of the option group | string | `` | no |
+| option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
+| options | A list of Options to apply. | any | `<list>` | no |
+| parameter_group_description | Description of the DB parameter group to create | string | `` | no |
+| parameter_group_name | Name of the DB parameter group to associate or create | string | `` | no |
+| parameters | A list of DB parameters (map) to apply | list(map(string)) | `<list>` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
+| port | The port on which the DB accepts connections | string | - | yes |
+| publicly_accessible | Bool to control if instance is publicly accessible | bool | `false` | no |
+| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
+| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `true` | no |
+| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
+| storage_encrypted | Specifies whether the DB instance is encrypted | bool | `false` | no |
+| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
+| subnet_ids | A list of VPC subnet IDs | list(string) | `<list>` | no |
 | tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| tags | A mapping of tags to assign to all resources | map(string) | `<map>` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `<map>` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| use_parameter_group_name_prefix | Whether to use the parameter group name prefix or not | bool | `true` | no |
+| username | Username for the master DB user | string | - | yes |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
+| vpc_security_group_ids | List of VPC security groups to associate | list(string) | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_db_instance_address | The address of the RDS instance |
+| this_db_instance_arn | The ARN of the RDS instance |
+| this_db_instance_availability_zone | The availability zone of the RDS instance |
+| this_db_instance_endpoint | The connection endpoint |
+| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this_db_instance_id | The RDS instance ID |
+| this_db_instance_name | The database name |
+| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this_db_instance_port | The database port |
+| this_db_instance_resource_id | The RDS Resource ID of this instance |
+| this_db_instance_status | The RDS instance status |
+| this_db_instance_username | The master username for the database |
+| this_db_option_group_arn | The ARN of the db option group |
+| this_db_option_group_id | The db option group id |
+| this_db_parameter_group_arn | The ARN of the db parameter group |
+| this_db_parameter_group_id | The db parameter group id |
+| this_db_subnet_group_arn | The ARN of the db subnet group |
+| this_db_subnet_group_id | The db subnet group name |
 | this_security_group_description | The description of the security group |
 | this_security_group_id | The ID of the security group |
 | this_security_group_name | The name of the security group |

--- a/tests/0.12/TEST-0.4.0.md
+++ b/tests/0.12/TEST-0.4.0.md
@@ -8,37 +8,37 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `[]` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
 | create | Whether to create security group and all rules | bool | `true` | no |
-| database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list(string) | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
+| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
+| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `[]` | no |
+| egress_rules | List of egress rules to create by name | list(string) | `[]` | no |
+| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
+| ingress_rules | List of ingress rules to create by name | list(string) | `[]` | no |
+| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
 | name | Name of security group | string | - | yes |
-| network | The network | object | `<map>` | no |
+| network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
 | number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
@@ -49,7 +49,7 @@ Stuff before terraform-docs
 | number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
-| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/tests/0.12/TEST-0.4.0.md
+++ b/tests/0.12/TEST-0.4.0.md
@@ -8,14 +8,61 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| create | Whether to create security group and all rules | bool | `true` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| description | Description of security group | string | `Security Group managed by Terraform` | no |
+| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
+| egress_rules | List of egress rules to create by name | list(string) | `<list>` | no |
+| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
+| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | number | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| vpc_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_security_group_description | The description of the security group |
+| this_security_group_id | The ID of the security group |
+| this_security_group_name | The name of the security group |
+| this_security_group_owner_id | The owner ID |
+| this_security_group_vpc_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-0.4.0.md
+++ b/tests/0.12/TEST-0.4.0.md
@@ -8,6 +8,14 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated_storage | The allocated storage in gigabytes | string | - | yes |
+| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | bool | `false` | no |
+| apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
+| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `true` | no |
+| availability_zone | The Availability Zone of the RDS instance | string | `` | no |
+| backup_retention_period | The days to retain backups for | number | `1` | no |
+| backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
+| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
 | computed_egress_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
 | computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
@@ -18,8 +26,16 @@ Stuff before terraform-docs
 | computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `false` | no |
 | create | Whether to create security group and all rules | bool | `true` | no |
+| create_db_instance | Whether to create a database instance | bool | `true` | no |
+| create_db_option_group | Whether to create a database option group | bool | `true` | no |
+| create_db_parameter_group | Whether to create a database parameter group | bool | `true` | no |
+| create_db_subnet_group | Whether to create a database subnet group | bool | `true` | no |
+| create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `false` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
+| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
+| deletion_protection | The database can't be deleted when this value is set to true. | bool | `false` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
 | egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
@@ -29,6 +45,13 @@ Stuff before terraform-docs
 | egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list(string) | `[]` | no |
+| engine | The database engine to use | string | - | yes |
+| engine_version | The engine version to use | string | - | yes |
+| family | The family of the DB parameter group | string | `` | no |
+| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
+| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
@@ -37,7 +60,18 @@ Stuff before terraform-docs
 | ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| instance_class | The instance type of the RDS instance | string | - | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `0` | no |
+| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
+| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
+| maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
+| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
+| monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | number | `0` | no |
+| monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
+| monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
+| multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
 | name | Name of security group | string | - | yes |
+| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
 | network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -49,15 +83,54 @@ Stuff before terraform-docs
 | number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| option_group_description | The description of the option group | string | `` | no |
+| option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
+| options | A list of Options to apply. | any | `[]` | no |
+| parameter_group_description | Description of the DB parameter group to create | string | `` | no |
+| parameter_group_name | Name of the DB parameter group to associate or create | string | `` | no |
+| parameters | A list of DB parameters (map) to apply | list(map(string)) | `[]` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
+| port | The port on which the DB accepts connections | string | - | yes |
+| publicly_accessible | Bool to control if instance is publicly accessible | bool | `false` | no |
+| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
+| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `true` | no |
+| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
+| storage_encrypted | Specifies whether the DB instance is encrypted | bool | `false` | no |
+| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
+| subnet_ids | A list of VPC subnet IDs | list(string) | `[]` | no |
 | tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
+| tags | A mapping of tags to assign to all resources | map(string) | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| use_parameter_group_name_prefix | Whether to use the parameter group name prefix or not | bool | `true` | no |
+| username | Username for the master DB user | string | - | yes |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
+| vpc_security_group_ids | List of VPC security groups to associate | list(string) | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_db_instance_address | The address of the RDS instance |
+| this_db_instance_arn | The ARN of the RDS instance |
+| this_db_instance_availability_zone | The availability zone of the RDS instance |
+| this_db_instance_endpoint | The connection endpoint |
+| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this_db_instance_id | The RDS instance ID |
+| this_db_instance_name | The database name |
+| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this_db_instance_port | The database port |
+| this_db_instance_resource_id | The RDS Resource ID of this instance |
+| this_db_instance_status | The RDS instance status |
+| this_db_instance_username | The master username for the database |
+| this_db_option_group_arn | The ARN of the db option group |
+| this_db_option_group_id | The db option group id |
+| this_db_parameter_group_arn | The ARN of the db parameter group |
+| this_db_parameter_group_id | The db parameter group id |
+| this_db_subnet_group_arn | The ARN of the db subnet group |
+| this_db_subnet_group_id | The db subnet group name |
 | this_security_group_description | The description of the security group |
 | this_security_group_id | The ID of the security group |
 | this_security_group_name | The name of the security group |

--- a/tests/0.12/TEST-0.4.5.md
+++ b/tests/0.12/TEST-0.4.5.md
@@ -7,6 +7,14 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated_storage | The allocated storage in gigabytes | string | - | yes |
+| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | bool | `false` | no |
+| apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
+| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `true` | no |
+| availability_zone | The Availability Zone of the RDS instance | string | `` | no |
+| backup_retention_period | The days to retain backups for | number | `1` | no |
+| backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
+| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
 | computed_egress_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
 | computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
@@ -17,8 +25,16 @@ Stuff before terraform-docs
 | computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `false` | no |
 | create | Whether to create security group and all rules | bool | `true` | no |
+| create_db_instance | Whether to create a database instance | bool | `true` | no |
+| create_db_option_group | Whether to create a database option group | bool | `true` | no |
+| create_db_parameter_group | Whether to create a database parameter group | bool | `true` | no |
+| create_db_subnet_group | Whether to create a database subnet group | bool | `true` | no |
+| create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `false` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
+| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
+| deletion_protection | The database can't be deleted when this value is set to true. | bool | `false` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
 | egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
@@ -28,6 +44,13 @@ Stuff before terraform-docs
 | egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list(string) | `[]` | no |
+| engine | The database engine to use | string | - | yes |
+| engine_version | The engine version to use | string | - | yes |
+| family | The family of the DB parameter group | string | `` | no |
+| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
+| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
@@ -36,7 +59,18 @@ Stuff before terraform-docs
 | ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| instance_class | The instance type of the RDS instance | string | - | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `0` | no |
+| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
+| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
+| maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
+| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
+| monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | number | `0` | no |
+| monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
+| monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
+| multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
 | name | Name of security group | string | - | yes |
+| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
 | network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -48,15 +82,54 @@ Stuff before terraform-docs
 | number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| option_group_description | The description of the option group | string | `` | no |
+| option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
+| options | A list of Options to apply. | any | `[]` | no |
+| parameter_group_description | Description of the DB parameter group to create | string | `` | no |
+| parameter_group_name | Name of the DB parameter group to associate or create | string | `` | no |
+| parameters | A list of DB parameters (map) to apply | list(map(string)) | `[]` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
+| port | The port on which the DB accepts connections | string | - | yes |
+| publicly_accessible | Bool to control if instance is publicly accessible | bool | `false` | no |
+| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
+| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `true` | no |
+| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
+| storage_encrypted | Specifies whether the DB instance is encrypted | bool | `false` | no |
+| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
+| subnet_ids | A list of VPC subnet IDs | list(string) | `[]` | no |
 | tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
+| tags | A mapping of tags to assign to all resources | map(string) | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| use_parameter_group_name_prefix | Whether to use the parameter group name prefix or not | bool | `true` | no |
+| username | Username for the master DB user | string | - | yes |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
+| vpc_security_group_ids | List of VPC security groups to associate | list(string) | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_db_instance_address | The address of the RDS instance |
+| this_db_instance_arn | The ARN of the RDS instance |
+| this_db_instance_availability_zone | The availability zone of the RDS instance |
+| this_db_instance_endpoint | The connection endpoint |
+| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this_db_instance_id | The RDS instance ID |
+| this_db_instance_name | The database name |
+| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this_db_instance_port | The database port |
+| this_db_instance_resource_id | The RDS Resource ID of this instance |
+| this_db_instance_status | The RDS instance status |
+| this_db_instance_username | The master username for the database |
+| this_db_option_group_arn | The ARN of the db option group |
+| this_db_option_group_id | The db option group id |
+| this_db_parameter_group_arn | The ARN of the db parameter group |
+| this_db_parameter_group_id | The db parameter group id |
+| this_db_subnet_group_arn | The ARN of the db subnet group |
+| this_db_subnet_group_id | The db subnet group name |
 | this_security_group_description | The description of the security group |
 | this_security_group_id | The ID of the security group |
 | this_security_group_name | The name of the security group |

--- a/tests/0.12/TEST-0.4.5.md
+++ b/tests/0.12/TEST-0.4.5.md
@@ -7,37 +7,37 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `[]` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
 | create | Whether to create security group and all rules | bool | `true` | no |
-| database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list(string) | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
+| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
+| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `[]` | no |
+| egress_rules | List of egress rules to create by name | list(string) | `[]` | no |
+| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
+| ingress_rules | List of ingress rules to create by name | list(string) | `[]` | no |
+| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
 | name | Name of security group | string | - | yes |
-| network | The network | object | `<map>` | no |
+| network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
 | number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
@@ -48,7 +48,7 @@ Stuff before terraform-docs
 | number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
-| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/tests/0.12/TEST-0.4.5.md
+++ b/tests/0.12/TEST-0.4.5.md
@@ -7,14 +7,61 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| computed_egress_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| create | Whether to create security group and all rules | bool | `true` | no |
 | database_outbound_acl_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| description | Description of security group | string | `Security Group managed by Terraform` | no |
+| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
+| egress_rules | List of egress rules to create by name | list(string) | `<list>` | no |
+| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress_with_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
+| ingress_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
+| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress_with_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | number | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| vpc_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this_security_group_description | The description of the security group |
+| this_security_group_id | The ID of the security group |
+| this_security_group_name | The name of the security group |
+| this_security_group_owner_id | The owner ID |
+| this_security_group_vpc_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-0.5.0.md
+++ b/tests/0.12/TEST-0.5.0.md
@@ -7,8 +7,24 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated\_storage | The allocated storage in gigabytes | string | - | yes |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
+| engine | The database engine to use | string | - | yes |
+| engine\_version | The engine version to use | string | - | yes |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
+| instance\_class | The instance type of the RDS instance | string | - | yes |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
 | name | Name of security group | string | - | yes |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
+| port | The port on which the DB accepts connections | string | - | yes |
+| username | Username for the master DB user | string | - | yes |
 | vpc\_id | ID of the VPC where to create security group | string | - | yes |
+| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | bool | `false` | no |
+| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `false` | no |
+| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `true` | no |
+| availability\_zone | The Availability Zone of the RDS instance | string | `` | no |
+| backup\_retention\_period | The days to retain backups for | number | `1` | no |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
 | computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
 | computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
@@ -19,8 +35,16 @@ Stuff before terraform-docs
 | computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `false` | no |
 | create | Whether to create security group and all rules | bool | `true` | no |
+| create\_db\_instance | Whether to create a database instance | bool | `true` | no |
+| create\_db\_option\_group | Whether to create a database option group | bool | `true` | no |
+| create\_db\_parameter\_group | Whether to create a database parameter group | bool | `true` | no |
+| create\_db\_subnet\_group | Whether to create a database subnet group | bool | `true` | no |
+| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `false` | no |
 | database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
+| deletion\_protection | The database can't be deleted when this value is set to true. | bool | `false` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
 | egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
@@ -30,6 +54,10 @@ Stuff before terraform-docs
 | egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list(string) | `[]` | no |
+| family | The family of the DB parameter group | string | `` | no |
+| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
+| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
 | ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
@@ -38,6 +66,15 @@ Stuff before terraform-docs
 | ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `0` | no |
+| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
+| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
+| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
+| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | number | `0` | no |
+| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
+| monitoring\_role\_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
+| multi\_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
+| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
 | network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -49,14 +86,50 @@ Stuff before terraform-docs
 | number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| option\_group\_description | The description of the option group | string | `` | no |
+| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
+| options | A list of Options to apply. | any | `[]` | no |
+| parameter\_group\_description | Description of the DB parameter group to create | string | `` | no |
+| parameter\_group\_name | Name of the DB parameter group to associate or create | string | `` | no |
+| parameters | A list of DB parameters (map) to apply | list(map(string)) | `[]` | no |
+| publicly\_accessible | Bool to control if instance is publicly accessible | bool | `false` | no |
+| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
+| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `true` | no |
+| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
+| storage\_encrypted | Specifies whether the DB instance is encrypted | bool | `false` | no |
+| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
+| subnet\_ids | A list of VPC subnet IDs | list(string) | `[]` | no |
 | tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
+| tags | A mapping of tags to assign to all resources | map(string) | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | bool | `true` | no |
+| vpc\_security\_group\_ids | List of VPC security groups to associate | list(string) | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
+| this\_db\_option\_group\_arn | The ARN of the db option group |
+| this\_db\_option\_group\_id | The db option group id |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 | this\_security\_group\_description | The description of the security group |
 | this\_security\_group\_id | The ID of the security group |
 | this\_security\_group\_name | The name of the security group |

--- a/tests/0.12/TEST-0.5.0.md
+++ b/tests/0.12/TEST-0.5.0.md
@@ -7,14 +7,61 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| create | Whether to create security group and all rules | bool | `true` | no |
 | database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| description | Description of security group | string | `Security Group managed by Terraform` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
+| egress\_rules | List of egress rules to create by name | list(string) | `<list>` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | number | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | number | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | number | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-0.5.0.md
+++ b/tests/0.12/TEST-0.5.0.md
@@ -7,37 +7,38 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
-| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
-| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| create | Whether to create security group and all rules | bool | `true` | no |
-| database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
-| description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
-| egress\_rules | List of egress rules to create by name | list(string) | `<list>` | no |
-| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
-| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
 | name | Name of security group | string | - | yes |
-| network | The network | object | `<map>` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
+| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| create | Whether to create security group and all rules | bool | `true` | no |
+| database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
+| description | Description of security group | string | `Security Group managed by Terraform` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list(string) | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list(string) | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
 | number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
@@ -48,9 +49,8 @@ Stuff before terraform-docs
 | number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `0` | no |
 | number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `0` | no |
 | number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `0` | no |
-| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
 | use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `true` | no |
-| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 

--- a/tests/0.12/TEST-0.6.0.md
+++ b/tests/0.12/TEST-0.6.0.md
@@ -7,37 +7,38 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
-| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
-| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| create | Whether to create security group and all rules | bool | `"true"` | no |
-| database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
-| description | Description of security group | string | `"Security Group managed by Terraform"` | no |
-| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
-| egress\_rules | List of egress rules to create by name | list(string) | `<list>` | no |
-| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
-| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
 | name | Name of security group | string | n/a | yes |
-| network | The network | object | `<map>` | no |
+| vpc\_id | ID of the VPC where to create security group | string | n/a | yes |
+| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| create | Whether to create security group and all rules | bool | `"true"` | no |
+| database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
+| description | Description of security group | string | `"Security Group managed by Terraform"` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list(string) | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list(string) | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `"0"` | no |
 | number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `"0"` | no |
 | number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
@@ -48,9 +49,8 @@ Stuff before terraform-docs
 | number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
 | number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `"0"` | no |
 | number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `"0"` | no |
-| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
 | use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `"true"` | no |
-| vpc\_id | ID of the VPC where to create security group | string | n/a | yes |
 
 ## Outputs
 

--- a/tests/0.12/TEST-0.6.0.md
+++ b/tests/0.12/TEST-0.6.0.md
@@ -7,14 +7,61 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| create | Whether to create security group and all rules | bool | `"true"` | no |
 | database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| description | Description of security group | string | `"Security Group managed by Terraform"` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
+| egress\_rules | List of egress rules to create by name | list(string) | `<list>` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| name | Name of security group | string | n/a | yes |
 | network | The network | object | `<map>` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `"0"` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `"0"` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | number | `"0"` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | number | `"0"` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | number | `"0"` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | number | `"0"` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `"0"` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `"0"` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `"true"` | no |
+| vpc\_id | ID of the VPC where to create security group | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-0.6.0.md
+++ b/tests/0.12/TEST-0.6.0.md
@@ -7,8 +7,24 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated\_storage | The allocated storage in gigabytes | string | n/a | yes |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
+| engine | The database engine to use | string | n/a | yes |
+| engine\_version | The engine version to use | string | n/a | yes |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
+| instance\_class | The instance type of the RDS instance | string | n/a | yes |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
 | name | Name of security group | string | n/a | yes |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
+| port | The port on which the DB accepts connections | string | n/a | yes |
+| username | Username for the master DB user | string | n/a | yes |
 | vpc\_id | ID of the VPC where to create security group | string | n/a | yes |
+| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | bool | `"false"` | no |
+| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `"false"` | no |
+| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `"true"` | no |
+| availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
+| backup\_retention\_period | The days to retain backups for | number | `"1"` | no |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
 | computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
 | computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
@@ -19,8 +35,16 @@ Stuff before terraform-docs
 | computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `"false"` | no |
 | create | Whether to create security group and all rules | bool | `"true"` | no |
+| create\_db\_instance | Whether to create a database instance | bool | `"true"` | no |
+| create\_db\_option\_group | Whether to create a database option group | bool | `"true"` | no |
+| create\_db\_parameter\_group | Whether to create a database parameter group | bool | `"true"` | no |
+| create\_db\_subnet\_group | Whether to create a database subnet group | bool | `"true"` | no |
+| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `"false"` | no |
 | database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
+| deletion\_protection | The database can't be deleted when this value is set to true. | bool | `"false"` | no |
 | description | Description of security group | string | `"Security Group managed by Terraform"` | no |
 | egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
 | egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
@@ -30,6 +54,10 @@ Stuff before terraform-docs
 | egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list(string) | `[]` | no |
+| family | The family of the DB parameter group | string | `""` | no |
+| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"null"` | no |
+| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `"false"` | no |
 | ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
@@ -38,6 +66,15 @@ Stuff before terraform-docs
 | ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `"0"` | no |
+| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
+| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
+| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `""` | no |
+| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | number | `"0"` | no |
+| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |
+| monitoring\_role\_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `"rds-monitoring-role"` | no |
+| multi\_az | Specifies if the RDS instance is multi-AZ | bool | `"false"` | no |
+| name | The DB name to create. If omitted, no database is created initially | string | `""` | no |
 | network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `"0"` | no |
 | number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `"0"` | no |
@@ -49,14 +86,50 @@ Stuff before terraform-docs
 | number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
 | number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `"0"` | no |
 | number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `"0"` | no |
+| option\_group\_description | The description of the option group | string | `""` | no |
+| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `""` | no |
+| options | A list of Options to apply. | any | `[]` | no |
+| parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
+| parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |
+| parameters | A list of DB parameters (map) to apply | list(map(string)) | `[]` | no |
+| publicly\_accessible | Bool to control if instance is publicly accessible | bool | `"false"` | no |
+| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |
+| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `"true"` | no |
+| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `""` | no |
+| storage\_encrypted | Specifies whether the DB instance is encrypted | bool | `"false"` | no |
+| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `"gp2"` | no |
+| subnet\_ids | A list of VPC subnet IDs | list(string) | `[]` | no |
 | tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
+| tags | A mapping of tags to assign to all resources | map(string) | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `""` | no |
 | use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `"true"` | no |
+| use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | bool | `"true"` | no |
+| vpc\_security\_group\_ids | List of VPC security groups to associate | list(string) | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
+| this\_db\_option\_group\_arn | The ARN of the db option group |
+| this\_db\_option\_group\_id | The db option group id |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 | this\_security\_group\_description | The description of the security group |
 | this\_security\_group\_id | The ID of the security group |
 | this\_security\_group\_name | The name of the security group |

--- a/tests/0.12/TEST-latest.md
+++ b/tests/0.12/TEST-latest.md
@@ -7,37 +7,38 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
-| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
-| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| create | Whether to create security group and all rules | bool | `"true"` | no |
-| database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
-| description | Description of security group | string | `"Security Group managed by Terraform"` | no |
-| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
-| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
-| egress\_rules | List of egress rules to create by name | list(string) | `<list>` | no |
-| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
-| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
-| ingress\_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
-| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
-| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
-| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
 | name | Name of security group | string | n/a | yes |
-| network | The network | object | `<map>` | no |
+| vpc\_id | ID of the VPC where to create security group | string | n/a | yes |
+| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| create | Whether to create security group and all rules | bool | `"true"` | no |
+| database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
+| description | Description of security group | string | `"Security Group managed by Terraform"` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list(string) | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list(string) | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `"0"` | no |
 | number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `"0"` | no |
 | number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
@@ -48,9 +49,8 @@ Stuff before terraform-docs
 | number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
 | number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `"0"` | no |
 | number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `"0"` | no |
-| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
 | use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `"true"` | no |
-| vpc\_id | ID of the VPC where to create security group | string | n/a | yes |
 
 ## Outputs
 

--- a/tests/0.12/TEST-latest.md
+++ b/tests/0.12/TEST-latest.md
@@ -7,14 +7,61 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `<list>` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list(string) | `<list>` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| create | Whether to create security group and all rules | bool | `"true"` | no |
 | database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `<list>` | no |
+| description | Description of security group | string | `"Security Group managed by Terraform"` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `<list>` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list(string) | `<list>` | no |
+| egress\_rules | List of egress rules to create by name | list(string) | `<list>` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
+| ingress\_rules | List of ingress rules to create by name | list(string) | `<list>` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `<list>` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `<list>` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `<list>` | no |
+| name | Name of security group | string | n/a | yes |
 | network | The network | object | `<map>` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `"0"` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `"0"` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | number | `"0"` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | number | `"0"` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | number | `"0"` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | number | `"0"` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `"0"` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `"0"` | no |
+| tags | A mapping of tags to assign to security group | map(string) | `<map>` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `"true"` | no |
+| vpc\_id | ID of the VPC where to create security group | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->	
 

--- a/tests/0.12/TEST-latest.md
+++ b/tests/0.12/TEST-latest.md
@@ -7,8 +7,24 @@ Stuff before terraform-docs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated\_storage | The allocated storage in gigabytes | string | n/a | yes |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
+| engine | The database engine to use | string | n/a | yes |
+| engine\_version | The engine version to use | string | n/a | yes |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
+| instance\_class | The instance type of the RDS instance | string | n/a | yes |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
 | name | Name of security group | string | n/a | yes |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
+| port | The port on which the DB accepts connections | string | n/a | yes |
+| username | Username for the master DB user | string | n/a | yes |
 | vpc\_id | ID of the VPC where to create security group | string | n/a | yes |
+| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | bool | `"false"` | no |
+| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | bool | `"false"` | no |
+| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `"true"` | no |
+| availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
+| backup\_retention\_period | The days to retain backups for | number | `"1"` | no |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
 | computed\_egress\_rules | List of computed egress rules to create by name | list(string) | `[]` | no |
 | computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
@@ -19,8 +35,16 @@ Stuff before terraform-docs
 | computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `"false"` | no |
 | create | Whether to create security group and all rules | bool | `"true"` | no |
+| create\_db\_instance | Whether to create a database instance | bool | `"true"` | no |
+| create\_db\_option\_group | Whether to create a database option group | bool | `"true"` | no |
+| create\_db\_parameter\_group | Whether to create a database parameter group | bool | `"true"` | no |
+| create\_db\_subnet\_group | Whether to create a database subnet group | bool | `"true"` | no |
+| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `"false"` | no |
 | database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
+| deletion\_protection | The database can't be deleted when this value is set to true. | bool | `"false"` | no |
 | description | Description of security group | string | `"Security Group managed by Terraform"` | no |
 | egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list(string) | `[ "0.0.0.0/0" ]` | no |
 | egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list(string) | `[ "::/0" ]` | no |
@@ -30,6 +54,10 @@ Stuff before terraform-docs
 | egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | egress\_with\_self | List of egress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list(string) | `[]` | no |
+| family | The family of the DB parameter group | string | `""` | no |
+| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"null"` | no |
+| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `"false"` | no |
 | ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
@@ -38,6 +66,15 @@ Stuff before terraform-docs
 | ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list(map(string)) | `[]` | no |
 | ingress\_with\_self | List of ingress rules to create where 'self' is defined | list(map(string)) | `[]` | no |
 | ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list(map(string)) | `[]` | no |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | number | `"0"` | no |
+| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
+| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
+| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `""` | no |
+| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | number | `"0"` | no |
+| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |
+| monitoring\_role\_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `"rds-monitoring-role"` | no |
+| multi\_az | Specifies if the RDS instance is multi-AZ | bool | `"false"` | no |
+| name | The DB name to create. If omitted, no database is created initially | string | `""` | no |
 | network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | number | `"0"` | no |
 | number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `"0"` | no |
@@ -49,14 +86,50 @@ Stuff before terraform-docs
 | number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | number | `"0"` | no |
 | number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | number | `"0"` | no |
 | number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | number | `"0"` | no |
+| option\_group\_description | The description of the option group | string | `""` | no |
+| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `""` | no |
+| options | A list of Options to apply. | any | `[]` | no |
+| parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
+| parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |
+| parameters | A list of DB parameters (map) to apply | list(map(string)) | `[]` | no |
+| publicly\_accessible | Bool to control if instance is publicly accessible | bool | `"false"` | no |
+| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |
+| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `"true"` | no |
+| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `""` | no |
+| storage\_encrypted | Specifies whether the DB instance is encrypted | bool | `"false"` | no |
+| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `"gp2"` | no |
+| subnet\_ids | A list of VPC subnet IDs | list(string) | `[]` | no |
 | tags | A mapping of tags to assign to security group | map(string) | `{}` | no |
+| tags | A mapping of tags to assign to all resources | map(string) | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map(string) | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `""` | no |
 | use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | bool | `"true"` | no |
+| use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | bool | `"true"` | no |
+| vpc\_security\_group\_ids | List of VPC security groups to associate | list(string) | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | environment | The output |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
+| this\_db\_option\_group\_arn | The ARN of the db option group |
+| this\_db\_option\_group\_id | The db option group id |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 | this\_security\_group\_description | The description of the security group |
 | this\_security\_group\_id | The ID of the security group |
 | this\_security\_group\_name | The name of the security group |

--- a/tests/0.12/main.tf
+++ b/tests/0.12/main.tf
@@ -50,3 +50,342 @@ output "environment" {
     }
   }
 }
+
+###################################################################################################
+#
+# https://github.com/terraform-aws-modules/terraform-aws-security-group: variables.tf
+#
+###################################################################################################
+
+#################
+# Security group
+#################
+variable "create" {
+  description = "Whether to create security group and all rules"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where to create security group"
+  type        = string
+}
+
+variable "name" {
+  description = "Name of security group"
+  type        = string
+}
+
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  type        = bool
+  default     = true
+}
+
+variable "description" {
+  description = "Description of security group"
+  type        = string
+  default     = "Security Group managed by Terraform"
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to security group"
+  type        = map(string)
+  default     = {}
+}
+
+##########
+# Ingress
+##########
+variable "ingress_rules" {
+  description = "List of ingress rules to create by name"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_with_self" {
+  description = "List of ingress rules to create where 'self' is defined"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ingress_with_cidr_blocks" {
+  description = "List of ingress rules to create where 'cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ingress_with_ipv6_cidr_blocks" {
+  description = "List of ingress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ingress_with_source_security_group_id" {
+  description = "List of ingress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  type        = list(string)
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  type        = number
+  default     = 0
+}
+
+#########
+# Egress
+#########
+variable "egress_rules" {
+  description = "List of egress rules to create by name"
+  type        = list(string)
+  default     = []
+}
+
+variable "egress_with_self" {
+  description = "List of egress rules to create where 'self' is defined"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "egress_with_cidr_blocks" {
+  description = "List of egress rules to create where 'cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "egress_with_ipv6_cidr_blocks" {
+  description = "List of egress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "egress_with_source_security_group_id" {
+  description = "List of egress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all egress rules"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all egress rules"
+  type        = list(string)
+  default     = ["::/0"]
+}
+
+variable "egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
+  type        = list(string)
+  default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  type        = list(string)
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  type        = number
+  default     = 0
+}
+
+
+###################################################################################################
+#
+# https://github.com/terraform-aws-modules/terraform-aws-security-group: outputs.tf
+#
+###################################################################################################
+
+
+output "this_security_group_id" {
+  description = "The ID of the security group"
+  value = concat(
+    aws_security_group.this.*.id,
+    aws_security_group.this_name_prefix.*.id,
+    [""],
+  )[0]
+}
+
+output "this_security_group_vpc_id" {
+  description = "The VPC ID"
+  value = concat(
+    aws_security_group.this.*.vpc_id,
+    aws_security_group.this_name_prefix.*.vpc_id,
+    [""],
+  )[0]
+}
+
+output "this_security_group_owner_id" {
+  description = "The owner ID"
+  value = concat(
+    aws_security_group.this.*.owner_id,
+    aws_security_group.this_name_prefix.*.owner_id,
+    [""],
+  )[0]
+}
+
+output "this_security_group_name" {
+  description = "The name of the security group"
+  value = concat(
+    aws_security_group.this.*.name,
+    aws_security_group.this_name_prefix.*.name,
+    [""],
+  )[0]
+}
+
+output "this_security_group_description" {
+  description = "The description of the security group"
+  value = concat(
+    aws_security_group.this.*.description,
+    aws_security_group.this_name_prefix.*.description,
+    [""],
+  )[0]
+}
+
+//output "this_security_group_ingress" {
+//  description = "The ingress rules"
+//  value       = "${element(concat(aws_security_group.this.*.ingress, list("")), 0)}"
+//}
+//output "this_security_group_egress" {
+//  description = "The egress rules"
+//    value       = "${element(concat(aws_security_group.this.*.egress, list("")), 0)"
+//}

--- a/tests/0.12/main.tf
+++ b/tests/0.12/main.tf
@@ -51,6 +51,437 @@ output "environment" {
   }
 }
 
+
+###################################################################################################
+#
+# https://github.com/terraform-aws-modules/terraform-aws-rds: variables.tf
+#
+###################################################################################################
+variable "identifier" {
+  description = "The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier"
+  type        = string
+}
+
+variable "allocated_storage" {
+  description = "The allocated storage in gigabytes"
+  type        = string
+}
+
+variable "storage_type" {
+  description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'."
+  type        = string
+  default     = "gp2"
+}
+
+variable "storage_encrypted" {
+  description = "Specifies whether the DB instance is encrypted"
+  type        = bool
+  default     = false
+}
+
+variable "kms_key_id" {
+  description = "The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used"
+  type        = string
+  default     = ""
+}
+
+variable "replicate_source_db" {
+  description = "Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate."
+  type        = string
+  default     = ""
+}
+
+variable "snapshot_identifier" {
+  description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05."
+  type        = string
+  default     = ""
+}
+
+variable "license_model" {
+  description = "License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1"
+  type        = string
+  default     = ""
+}
+
+variable "iam_database_authentication_enabled" {
+  description = "Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "engine" {
+  description = "The database engine to use"
+  type        = string
+}
+
+variable "engine_version" {
+  description = "The engine version to use"
+  type        = string
+}
+
+variable "final_snapshot_identifier" {
+  description = "The name of your final DB snapshot when this DB instance is deleted."
+  type        = string
+  default     = null
+}
+
+variable "instance_class" {
+  description = "The instance type of the RDS instance"
+  type        = string
+}
+
+variable "name" {
+  description = "The DB name to create. If omitted, no database is created initially"
+  type        = string
+  default     = ""
+}
+
+variable "username" {
+  description = "Username for the master DB user"
+  type        = string
+}
+
+variable "password" {
+  description = "Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file"
+  type        = string
+}
+
+variable "port" {
+  description = "The port on which the DB accepts connections"
+  type        = string
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of VPC security groups to associate"
+  type        = list(string)
+  default     = []
+}
+
+variable "db_subnet_group_name" {
+  description = "Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC"
+  type        = string
+  default     = ""
+}
+
+variable "parameter_group_description" {
+  description = "Description of the DB parameter group to create"
+  type        = string
+  default     = ""
+}
+
+variable "parameter_group_name" {
+  description = "Name of the DB parameter group to associate or create"
+  type        = string
+  default     = ""
+}
+
+variable "option_group_name" {
+  description = "Name of the DB option group to associate. Setting this automatically disables option_group creation"
+  type        = string
+  default     = ""
+}
+
+variable "availability_zone" {
+  description = "The Availability Zone of the RDS instance"
+  type        = string
+  default     = ""
+}
+
+variable "multi_az" {
+  description = "Specifies if the RDS instance is multi-AZ"
+  type        = bool
+  default     = false
+}
+
+variable "iops" {
+  description = "The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'"
+  type        = number
+  default     = 0
+}
+
+variable "publicly_accessible" {
+  description = "Bool to control if instance is publicly accessible"
+  type        = bool
+  default     = false
+}
+
+variable "monitoring_interval" {
+  description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60."
+  type        = number
+  default     = 0
+}
+
+variable "monitoring_role_arn" {
+  description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero."
+  type        = string
+  default     = ""
+}
+
+variable "monitoring_role_name" {
+  description = "Name of the IAM role which will be created when create_monitoring_role is enabled."
+  type        = string
+  default     = "rds-monitoring-role"
+}
+
+variable "create_monitoring_role" {
+  description = "Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs."
+  type        = bool
+  default     = false
+}
+
+variable "allow_major_version_upgrade" {
+  description = "Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible"
+  type        = bool
+  default     = false
+}
+
+variable "auto_minor_version_upgrade" {
+  description = "Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window"
+  type        = bool
+  default     = true
+}
+
+variable "apply_immediately" {
+  description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window"
+  type        = bool
+  default     = false
+}
+
+variable "maintenance_window" {
+  description = "The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00'"
+  type        = string
+}
+
+variable "skip_final_snapshot" {
+  description = "Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier"
+  type        = bool
+  default     = true
+}
+
+variable "copy_tags_to_snapshot" {
+  description = "On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified)"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_period" {
+  description = "The days to retain backups for"
+  type        = number
+  default     = 1
+}
+
+variable "backup_window" {
+  description = "The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window"
+  type        = string
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# DB subnet group
+variable "subnet_ids" {
+  description = "A list of VPC subnet IDs"
+  type        = list(string)
+  default     = []
+}
+
+# DB parameter group
+variable "family" {
+  description = "The family of the DB parameter group"
+  type        = string
+  default     = ""
+}
+
+variable "parameters" {
+  description = "A list of DB parameters (map) to apply"
+  type        = list(map(string))
+  default     = []
+}
+
+# DB option group
+variable "option_group_description" {
+  description = "The description of the option group"
+  type        = string
+  default     = ""
+}
+
+variable "major_engine_version" {
+  description = "Specifies the major version of the engine that this option group should be associated with"
+  type        = string
+  default     = ""
+}
+
+variable "options" {
+  description = "A list of Options to apply."
+  type        = any
+  default     = []
+}
+
+variable "create_db_subnet_group" {
+  description = "Whether to create a database subnet group"
+  type        = bool
+  default     = true
+}
+
+variable "create_db_parameter_group" {
+  description = "Whether to create a database parameter group"
+  type        = bool
+  default     = true
+}
+
+variable "create_db_option_group" {
+  description = "Whether to create a database option group"
+  type        = bool
+  default     = true
+}
+
+variable "create_db_instance" {
+  description = "Whether to create a database instance"
+  type        = bool
+  default     = true
+}
+
+variable "timezone" {
+  description = "(Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information."
+  type        = string
+  default     = ""
+}
+
+variable "character_set_name" {
+  description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information"
+  type        = string
+  default     = ""
+}
+
+variable "enabled_cloudwatch_logs_exports" {
+  description = "List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL)."
+  type        = list(string)
+  default     = []
+}
+
+variable "timeouts" {
+  description = "(Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times"
+  type        = map(string)
+  default = {
+    create = "40m"
+    update = "80m"
+    delete = "40m"
+  }
+}
+
+variable "deletion_protection" {
+  description = "The database can't be deleted when this value is set to true."
+  type        = bool
+  default     = false
+}
+
+variable "use_parameter_group_name_prefix" {
+  description = "Whether to use the parameter group name prefix or not"
+  type        = bool
+  default     = true
+}
+
+
+###################################################################################################
+#
+# https://github.com/terraform-aws-modules/terraform-aws-rds: outputs.tf
+#
+###################################################################################################
+
+output "this_db_instance_address" {
+  description = "The address of the RDS instance"
+  value       = module.db_instance.this_db_instance_address
+}
+
+output "this_db_instance_arn" {
+  description = "The ARN of the RDS instance"
+  value       = module.db_instance.this_db_instance_arn
+}
+
+output "this_db_instance_availability_zone" {
+  description = "The availability zone of the RDS instance"
+  value       = module.db_instance.this_db_instance_availability_zone
+}
+
+output "this_db_instance_endpoint" {
+  description = "The connection endpoint"
+  value       = module.db_instance.this_db_instance_endpoint
+}
+
+output "this_db_instance_hosted_zone_id" {
+  description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
+  value       = module.db_instance.this_db_instance_hosted_zone_id
+}
+
+output "this_db_instance_id" {
+  description = "The RDS instance ID"
+  value       = module.db_instance.this_db_instance_id
+}
+
+output "this_db_instance_resource_id" {
+  description = "The RDS Resource ID of this instance"
+  value       = module.db_instance.this_db_instance_resource_id
+}
+
+output "this_db_instance_status" {
+  description = "The RDS instance status"
+  value       = module.db_instance.this_db_instance_status
+}
+
+output "this_db_instance_name" {
+  description = "The database name"
+  value       = module.db_instance.this_db_instance_name
+}
+
+output "this_db_instance_username" {
+  description = "The master username for the database"
+  value       = module.db_instance.this_db_instance_username
+}
+
+output "this_db_instance_password" {
+  description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
+  value       = var.password
+}
+
+output "this_db_instance_port" {
+  description = "The database port"
+  value       = module.db_instance.this_db_instance_port
+}
+
+output "this_db_subnet_group_id" {
+  description = "The db subnet group name"
+  value       = module.db_subnet_group.this_db_subnet_group_id
+}
+
+output "this_db_subnet_group_arn" {
+  description = "The ARN of the db subnet group"
+  value       = module.db_subnet_group.this_db_subnet_group_arn
+}
+
+output "this_db_parameter_group_id" {
+  description = "The db parameter group id"
+  value       = module.db_parameter_group.this_db_parameter_group_id
+}
+
+output "this_db_parameter_group_arn" {
+  description = "The ARN of the db parameter group"
+  value       = module.db_parameter_group.this_db_parameter_group_arn
+}
+
+# DB option group
+output "this_db_option_group_id" {
+  description = "The db option group id"
+  value       = module.db_option_group.this_db_option_group_id
+}
+
+output "this_db_option_group_arn" {
+  description = "The ARN of the db option group"
+  value       = module.db_option_group.this_db_option_group_arn
+}
+
 ###################################################################################################
 #
 # https://github.com/terraform-aws-modules/terraform-aws-security-group: variables.tf

--- a/tests/default/TEST-0.4.0.md
+++ b/tests/default/TEST-0.4.0.md
@@ -24,7 +24,7 @@ Stuff before terraform-docs
 | create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `false` | no |
 | db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
 | deletion_protection | The database can't be deleted when this value is set to true. | string | `false` | no |
-| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |
+| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `[]` | no |
 | engine | The database engine to use | string | - | yes |
 | engine_version | The engine version to use | string | - | yes |
 | family | The family of the DB parameter group | string | `` | no |
@@ -44,10 +44,10 @@ Stuff before terraform-docs
 | name | The DB schema name to create. If omitted, no database is created initially | string | `` | no |
 | option_group_description | The description of the option group | string | `` | no |
 | option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
-| options | A list of Options to apply. | list | `<list>` | no |
+| options | A list of Options to apply. | list | `[]` | no |
 | parameter_group_description | Description of the DB parameter group to create | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate or create | string | `` | no |
-| parameters | A list of DB parameters (map) to apply | list | `<list>` | no |
+| parameters | A list of DB parameters (map) to apply | list | `[]` | no |
 | password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
 | port | The port on which the DB accepts connections | string | - | yes |
 | publicly_accessible | Bool to control if instance is publicly accessible | string | `false` | no |
@@ -56,15 +56,15 @@ Stuff before terraform-docs
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
 | storage_encrypted | Specifies whether the DB instance is encrypted | string | `false` | no |
 | storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
-| subnet_ids | A list of VPC subnet IDs | list | `<list>` | no |
-| tags | A mapping of tags to assign to all resources | map | `<map>` | no |
-| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
+| subnet_ids | A list of VPC subnet IDs | list | `[]` | no |
+| tags | A mapping of tags to assign to all resources | map | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use_option_group_name_prefix | Whether to use the option group name prefix or not | string | `true` | no |
 | use_parameter_group_name_prefix | Whether to use the parameter group name prefix or not | string | `true` | no |
 | use_subnet_group_name_prefix | Whether to use the subnet group name prefix or not | string | `true` | no |
 | username | Username for the master DB user | string | - | yes |
-| vpc_security_group_ids | List of VPC security groups to associate | list | `<list>` | no |
+| vpc_security_group_ids | List of VPC security groups to associate | list | `[]` | no |
 
 ## Outputs
 

--- a/tests/default/TEST-0.4.5.md
+++ b/tests/default/TEST-0.4.5.md
@@ -23,7 +23,7 @@ Stuff before terraform-docs
 | create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `false` | no |
 | db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
 | deletion_protection | The database can't be deleted when this value is set to true. | string | `false` | no |
-| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |
+| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `[]` | no |
 | engine | The database engine to use | string | - | yes |
 | engine_version | The engine version to use | string | - | yes |
 | family | The family of the DB parameter group | string | `` | no |
@@ -43,10 +43,10 @@ Stuff before terraform-docs
 | name | The DB schema name to create. If omitted, no database is created initially | string | `` | no |
 | option_group_description | The description of the option group | string | `` | no |
 | option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
-| options | A list of Options to apply. | list | `<list>` | no |
+| options | A list of Options to apply. | list | `[]` | no |
 | parameter_group_description | Description of the DB parameter group to create | string | `` | no |
 | parameter_group_name | Name of the DB parameter group to associate or create | string | `` | no |
-| parameters | A list of DB parameters (map) to apply | list | `<list>` | no |
+| parameters | A list of DB parameters (map) to apply | list | `[]` | no |
 | password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
 | port | The port on which the DB accepts connections | string | - | yes |
 | publicly_accessible | Bool to control if instance is publicly accessible | string | `false` | no |
@@ -55,15 +55,15 @@ Stuff before terraform-docs
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
 | storage_encrypted | Specifies whether the DB instance is encrypted | string | `false` | no |
 | storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
-| subnet_ids | A list of VPC subnet IDs | list | `<list>` | no |
-| tags | A mapping of tags to assign to all resources | map | `<map>` | no |
-| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
+| subnet_ids | A list of VPC subnet IDs | list | `[]` | no |
+| tags | A mapping of tags to assign to all resources | map | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use_option_group_name_prefix | Whether to use the option group name prefix or not | string | `true` | no |
 | use_parameter_group_name_prefix | Whether to use the parameter group name prefix or not | string | `true` | no |
 | use_subnet_group_name_prefix | Whether to use the subnet group name prefix or not | string | `true` | no |
 | username | Username for the master DB user | string | - | yes |
-| vpc_security_group_ids | List of VPC security groups to associate | list | `<list>` | no |
+| vpc_security_group_ids | List of VPC security groups to associate | list | `[]` | no |
 
 ## Outputs
 

--- a/tests/default/TEST-0.5.0.md
+++ b/tests/default/TEST-0.5.0.md
@@ -8,12 +8,20 @@ Stuff before terraform-docs
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allocated\_storage | The allocated storage in gigabytes | string | - | yes |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
+| engine | The database engine to use | string | - | yes |
+| engine\_version | The engine version to use | string | - | yes |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
+| instance\_class | The instance type of the RDS instance | string | - | yes |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
+| port | The port on which the DB accepts connections | string | - | yes |
+| username | Username for the master DB user | string | - | yes |
 | allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `false` | no |
 | apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
 | auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `true` | no |
 | availability\_zone | The Availability Zone of the RDS instance | string | `` | no |
 | backup\_retention\_period | The days to retain backups for | string | `7` | no |
-| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
 | character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `false` | no |
 | create\_db\_instance | Whether to create a database instance | string | `true` | no |
@@ -23,18 +31,13 @@ Stuff before terraform-docs
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `false` | no |
 | db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
 | deletion\_protection | The database can't be deleted when this value is set to true. | string | `false` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |
-| engine | The database engine to use | string | - | yes |
-| engine\_version | The engine version to use | string | - | yes |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `[]` | no |
 | family | The family of the DB parameter group | string | `` | no |
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `false` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `false` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
-| instance\_class | The instance type of the RDS instance | string | - | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `0` | no |
 | kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
 | license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
-| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
 | major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `0` | no |
 | monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
@@ -43,27 +46,24 @@ Stuff before terraform-docs
 | name | The DB schema name to create. If omitted, no database is created initially | string | `` | no |
 | option\_group\_description | The description of the option group | string | `` | no |
 | option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
-| options | A list of Options to apply. | list | `<list>` | no |
+| options | A list of Options to apply. | list | `[]` | no |
 | parameter\_group\_description | Description of the DB parameter group to create | string | `` | no |
 | parameter\_group\_name | Name of the DB parameter group to associate or create | string | `` | no |
-| parameters | A list of DB parameters (map) to apply | list | `<list>` | no |
-| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
-| port | The port on which the DB accepts connections | string | - | yes |
+| parameters | A list of DB parameters (map) to apply | list | `[]` | no |
 | publicly\_accessible | Bool to control if instance is publicly accessible | string | `false` | no |
 | replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `false` | no |
 | snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
 | storage\_encrypted | Specifies whether the DB instance is encrypted | string | `false` | no |
 | storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
-| subnet\_ids | A list of VPC subnet IDs | list | `<list>` | no |
-| tags | A mapping of tags to assign to all resources | map | `<map>` | no |
-| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
+| subnet\_ids | A list of VPC subnet IDs | list | `[]` | no |
+| tags | A mapping of tags to assign to all resources | map | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
 | use\_option\_group\_name\_prefix | Whether to use the option group name prefix or not | string | `true` | no |
 | use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `true` | no |
 | use\_subnet\_group\_name\_prefix | Whether to use the subnet group name prefix or not | string | `true` | no |
-| username | Username for the master DB user | string | - | yes |
-| vpc\_security\_group\_ids | List of VPC security groups to associate | list | `<list>` | no |
+| vpc\_security\_group\_ids | List of VPC security groups to associate | list | `[]` | no |
 
 ## Outputs
 

--- a/tests/default/TEST-0.6.0.md
+++ b/tests/default/TEST-0.6.0.md
@@ -8,12 +8,20 @@ Stuff before terraform-docs
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allocated\_storage | The allocated storage in gigabytes | string | n/a | yes |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
+| engine | The database engine to use | string | n/a | yes |
+| engine\_version | The engine version to use | string | n/a | yes |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
+| instance\_class | The instance type of the RDS instance | string | n/a | yes |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
+| port | The port on which the DB accepts connections | string | n/a | yes |
+| username | Username for the master DB user | string | n/a | yes |
 | allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `"false"` | no |
 | apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `"false"` | no |
 | auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `"true"` | no |
 | availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
 | backup\_retention\_period | The days to retain backups for | string | `"7"` | no |
-| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
 | character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `"false"` | no |
 | create\_db\_instance | Whether to create a database instance | string | `"true"` | no |
@@ -23,18 +31,13 @@ Stuff before terraform-docs
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
 | db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
 | deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |
-| engine | The database engine to use | string | n/a | yes |
-| engine\_version | The engine version to use | string | n/a | yes |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `[]` | no |
 | family | The family of the DB parameter group | string | `""` | no |
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"false"` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `"false"` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
-| instance\_class | The instance type of the RDS instance | string | n/a | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
 | kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
 | license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
-| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
 | major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `""` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
 | monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |
@@ -43,27 +46,24 @@ Stuff before terraform-docs
 | name | The DB schema name to create. If omitted, no database is created initially | string | `""` | no |
 | option\_group\_description | The description of the option group | string | `""` | no |
 | option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `""` | no |
-| options | A list of Options to apply. | list | `<list>` | no |
+| options | A list of Options to apply. | list | `[]` | no |
 | parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
 | parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |
-| parameters | A list of DB parameters (map) to apply | list | `<list>` | no |
-| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
-| port | The port on which the DB accepts connections | string | n/a | yes |
+| parameters | A list of DB parameters (map) to apply | list | `[]` | no |
 | publicly\_accessible | Bool to control if instance is publicly accessible | string | `"false"` | no |
 | replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `"false"` | no |
 | snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `""` | no |
 | storage\_encrypted | Specifies whether the DB instance is encrypted | string | `"false"` | no |
 | storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `"gp2"` | no |
-| subnet\_ids | A list of VPC subnet IDs | list | `<list>` | no |
-| tags | A mapping of tags to assign to all resources | map | `<map>` | no |
-| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
+| subnet\_ids | A list of VPC subnet IDs | list | `[]` | no |
+| tags | A mapping of tags to assign to all resources | map | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `""` | no |
 | use\_option\_group\_name\_prefix | Whether to use the option group name prefix or not | string | `"true"` | no |
 | use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `"true"` | no |
 | use\_subnet\_group\_name\_prefix | Whether to use the subnet group name prefix or not | string | `"true"` | no |
-| username | Username for the master DB user | string | n/a | yes |
-| vpc\_security\_group\_ids | List of VPC security groups to associate | list | `<list>` | no |
+| vpc\_security\_group\_ids | List of VPC security groups to associate | list | `[]` | no |
 
 ## Outputs
 

--- a/tests/default/TEST-latest.md
+++ b/tests/default/TEST-latest.md
@@ -8,12 +8,20 @@ Stuff before terraform-docs
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allocated\_storage | The allocated storage in gigabytes | string | n/a | yes |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
+| engine | The database engine to use | string | n/a | yes |
+| engine\_version | The engine version to use | string | n/a | yes |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
+| instance\_class | The instance type of the RDS instance | string | n/a | yes |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
+| port | The port on which the DB accepts connections | string | n/a | yes |
+| username | Username for the master DB user | string | n/a | yes |
 | allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `"false"` | no |
 | apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `"false"` | no |
 | auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `"true"` | no |
 | availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
 | backup\_retention\_period | The days to retain backups for | string | `"7"` | no |
-| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
 | character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `"false"` | no |
 | create\_db\_instance | Whether to create a database instance | string | `"true"` | no |
@@ -23,18 +31,13 @@ Stuff before terraform-docs
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
 | db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
 | deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |
-| engine | The database engine to use | string | n/a | yes |
-| engine\_version | The engine version to use | string | n/a | yes |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `[]` | no |
 | family | The family of the DB parameter group | string | `""` | no |
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"false"` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `"false"` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
-| instance\_class | The instance type of the RDS instance | string | n/a | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
 | kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
 | license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
-| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
 | major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `""` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
 | monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |
@@ -43,27 +46,24 @@ Stuff before terraform-docs
 | name | The DB schema name to create. If omitted, no database is created initially | string | `""` | no |
 | option\_group\_description | The description of the option group | string | `""` | no |
 | option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `""` | no |
-| options | A list of Options to apply. | list | `<list>` | no |
+| options | A list of Options to apply. | list | `[]` | no |
 | parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
 | parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |
-| parameters | A list of DB parameters (map) to apply | list | `<list>` | no |
-| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
-| port | The port on which the DB accepts connections | string | n/a | yes |
+| parameters | A list of DB parameters (map) to apply | list | `[]` | no |
 | publicly\_accessible | Bool to control if instance is publicly accessible | string | `"false"` | no |
 | replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `"false"` | no |
 | snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `""` | no |
 | storage\_encrypted | Specifies whether the DB instance is encrypted | string | `"false"` | no |
 | storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `"gp2"` | no |
-| subnet\_ids | A list of VPC subnet IDs | list | `<list>` | no |
-| tags | A mapping of tags to assign to all resources | map | `<map>` | no |
-| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
+| subnet\_ids | A list of VPC subnet IDs | list | `[]` | no |
+| tags | A mapping of tags to assign to all resources | map | `{}` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `{ "create": "40m", "delete": "40m", "update": "80m" }` | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `""` | no |
 | use\_option\_group\_name\_prefix | Whether to use the option group name prefix or not | string | `"true"` | no |
 | use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `"true"` | no |
 | use\_subnet\_group\_name\_prefix | Whether to use the subnet group name prefix or not | string | `"true"` | no |
-| username | Username for the master DB user | string | n/a | yes |
-| vpc\_security\_group\_ids | List of VPC security groups to associate | list | `<list>` | no |
+| vpc\_security\_group\_ids | List of VPC security groups to associate | list | `[]` | no |
 
 ## Outputs
 


### PR DESCRIPTION
# Enhance terraform-docs.awk transformation for Terraform 0.12

This PR fixes some edge cases for transforming Terraform >= 0.12 variables/outputs to Terraform < 0.12 syntax in order to parse it with terraform-docs

* Refs: https://github.com/antonbabenko/pre-commit-terraform/issues/47
* Refs: https://github.com/cloudposse/build-harness/pull/155
* Refs: https://github.com/cloudposse/build-harness/pull/156

## Todo

* [x] Add all newly found edge cases to CI tests to ensure all changes will still be compatible with previous logic