### PR TITLE
Fix description key inside type

### DIFF
--- a/data/terraform-docs.awk
+++ b/data/terraform-docs.awk
@@ -14,79 +14,154 @@
     braceCnt--
   }
 
-  # [START] variable or output block started
-  if ($0 ~ /^[[:space:]]*(variable|output)[[:space:]][[:space:]]*"(.*?)"/) {
-    # Normalize the braceCnt (should be 1 now)
-    braceCnt = 1
-    # [CLOSE] "default" block
-    if (blockDefCnt > 0) {
-      blockDefCnt = 0
-    }
-    blockCnt++
-    print $0
-  }
 
-  # [START] multiline default statement started
-  if (blockCnt > 0) {
-    if ($0 ~ /^[[:space:]][[:space:]]*(default)[[:space:]][[:space:]]*=/) {
-      if ($3 ~ "null") {
-        print "  default = \"null\""
-      } else {
-        print $0
-        blockDefCnt++
-        blockDefStart=1
-      }
-    }
-  }
-
-  # [PRINT] single line "description"
-  if (blockCnt > 0) {
-    if (blockDefCnt == 0) {
-      if ($0 ~ /^[[:space:]][[:space:]]*description[[:space:]][[:space:]]*=/) {
-        # [CLOSE] "default" block
-        if (blockDefCnt > 0) {
-          blockDefCnt = 0
-        }
-        print $0
-      }
-    }
-  }
-
-  # [PRINT] single line "type"
-  if (blockCnt > 0) {
-    if ($0 ~ /^[[:space:]][[:space:]]*type[[:space:]][[:space:]]*=/ ) {
-      # [CLOSE] "default" block
-      if (blockDefCnt > 0) {
-        blockDefCnt = 0
-      }
-      type=$3
-      if (type ~ "object") {
-        print "  type = \"object\""
-      } else {
-          # legacy quoted types: "string", "list", and "map"
-          if ($3 ~ /^[[:space:]]*"(.*?)"[[:space:]]*$/) {
-            print "  type = " $3
-          } else {
-            print "  type = \"" $3 "\""
-          }
-      }
-    }
-  }
-
-  # [CLOSE] variable/output block
-  if (blockCnt > 0) {
+  # ----------------------------------------------------------------------------------------------
+  # variable|output "..." {
+  # ----------------------------------------------------------------------------------------------
+  # [END] variable/output block
+  if (blockCnt > 0 && blockTypeCnt == 0 && blockDefaultCnt == 0) {
     if (braceCnt == 0 && blockCnt > 0) {
       blockCnt--
       print $0
     }
   }
+  # [START] variable or output block started
+  if ($0 ~ /^[[:space:]]*(variable|output)[[:space:]][[:space:]]*"(.*?)"/) {
+    # Normalize the braceCnt and block (should be 1 now)
+    braceCnt = 1
+    blockCnt = 1
+    # [CLOSE] "default" and "type" block
+    blockDefaultCnt = 0
+    blockTypeCnt = 0
+    # Print variable|output line
+    print $0
+  }
 
-  # [PRINT] Multiline "default" statement
-  if (blockCnt > 0 && blockDefCnt > 0) {
-    if (blockDefStart == 1) {
-      blockDefStart = 0
-    } else {
+
+  # ----------------------------------------------------------------------------------------------
+  # default = ...
+  # ----------------------------------------------------------------------------------------------
+  # [END] multiline "default" continues/ends
+  if (blockCnt > 0 && blockTypeCnt == 0 && blockDefaultCnt > 0) {
+      print $0
+      # Count opening blocks
+      blockDefaultCnt += gsub(/\(/, "")
+      blockDefaultCnt += gsub(/\[/, "")
+      blockDefaultCnt += gsub(/\{/, "")
+      # Count closing blocks
+      blockDefaultCnt -= gsub(/\)/, "")
+      blockDefaultCnt -= gsub(/\]/, "")
+      blockDefaultCnt -= gsub(/\}/, "")
+  }
+  # [START] multiline "default" statement started
+  if (blockCnt > 0 && blockTypeCnt == 0 && blockDefaultCnt == 0) {
+    if ($0 ~ /^[[:space:]][[:space:]]*(default)[[:space:]][[:space:]]*=/) {
+      if ($3 ~ "null") {
+        print "  default = \"null\""
+      } else {
+        print $0
+        # Count opening blocks
+        blockDefaultCnt += gsub(/\(/, "")
+        blockDefaultCnt += gsub(/\[/, "")
+        blockDefaultCnt += gsub(/\{/, "")
+        # Count closing blocks
+        blockDefaultCnt -= gsub(/\)/, "")
+        blockDefaultCnt -= gsub(/\]/, "")
+        blockDefaultCnt -= gsub(/\}/, "")
+      }
+    }
+  }
+
+
+  # ----------------------------------------------------------------------------------------------
+  # type  = ...
+  # ----------------------------------------------------------------------------------------------
+  # [END] multiline "type" continues/ends
+  if (blockCnt > 0 && blockTypeCnt > 0 && blockDefaultCnt == 0) {
+    # The following 'print $0' would print multiline type definitions
+    #print $0
+    # Count opening blocks
+    blockTypeCnt += gsub(/\(/, "")
+    blockTypeCnt += gsub(/\[/, "")
+    blockTypeCnt += gsub(/\{/, "")
+    # Count closing blocks
+    blockTypeCnt -= gsub(/\)/, "")
+    blockTypeCnt -= gsub(/\]/, "")
+    blockTypeCnt -= gsub(/\}/, "")
+  }
+  # [START] multiline "type" statement started
+  if (blockCnt > 0 && blockTypeCnt == 0 && blockDefaultCnt == 0) {
+    if ($0 ~ /^[[:space:]][[:space:]]*(type)[[:space:]][[:space:]]*=/ ) {
+      if ($3 ~ "object") {
+        print "  type = \"object\""
+      } else {
+        # Convert multiline stuff into single line
+        if ($3 ~ /^[[:space:]]*list[[:space:]]*\([[:space:]]*$/) {
+          type = "list"
+        } else if ($3 ~ /^[[:space:]]*string[[:space:]]*\([[:space:]]*$/) {
+          type = "string"
+        } else if ($3 ~ /^[[:space:]]*map[[:space:]]*\([[:space:]]*$/) {
+          type = "map"
+        } else {
+          type = $3
+        }
+
+        # legacy quoted types: "string", "list", and "map"
+        if (type ~ /^[[:space:]]*"(.*?)"[[:space:]]*$/) {
+          print "  type = " type
+        } else {
+          print "  type = \"" type "\""
+        }
+      }
+      # Count opening blocks
+      blockTypeCnt += gsub(/\(/, "")
+      blockTypeCnt += gsub(/\[/, "")
+      blockTypeCnt += gsub(/\{/, "")
+      # Count closing blocks
+      blockTypeCnt -= gsub(/\)/, "")
+      blockTypeCnt -= gsub(/\]/, "")
+      blockTypeCnt -= gsub(/\}/, "")
+    }
+  }
+
+
+  # ----------------------------------------------------------------------------------------------
+  # description = ...
+  # ----------------------------------------------------------------------------------------------
+  # [PRINT] single line "description"
+  if (blockCnt > 0 && blockTypeCnt == 0 && blockDefaultCnt == 0) {
+    if ($0 ~ /^[[:space:]][[:space:]]*description[[:space:]][[:space:]]*=/) {
       print $0
     }
   }
+
+
+  # ----------------------------------------------------------------------------------------------
+  # value = ...
+  # ----------------------------------------------------------------------------------------------
+  ## [PRINT] single line "value"
+  #if (blockCnt > 0 && blockTypeCnt == 0 && blockDefaultCnt == 0) {
+  #  if ($0 ~ /^[[:space:]][[:space:]]*value[[:space:]][[:space:]]*=/) {
+  #    print $0
+  #  }
+  #}
+
+
+  # ----------------------------------------------------------------------------------------------
+  # Newlines, comments, everything else
+  # ----------------------------------------------------------------------------------------------
+  #if (blockTypeCnt == 0 && blockDefaultCnt == 0) {
+  # Comments with '#'
+  if ($0 ~ /^[[:space:]]*#/) {
+    print $0
+  }
+  # Comments with '//'
+  if ($0 ~ /^[[:space:]]*\/\//) {
+    print $0
+  }
+  # Newlines
+  if ($0 ~ /^[[:space:]]*$/) {
+    print $0
+  }
+  #}
 }

--- a/tests/0.12/TEST-0.1.0.md
+++ b/tests/0.12/TEST-0.1.0.md
@@ -52,6 +52,7 @@ Stuff before terraform-docs
 | final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | `null` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | - | yes |
+| ingress_cidr_blocks | Bzzzzz | `<list>` | no |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | `<list>` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | `<list>` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | `<list>` | no |
@@ -70,8 +71,8 @@ Stuff before terraform-docs
 | monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | `` | no |
 | monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | `rds-monitoring-role` | no |
 | multi_az | Specifies if the RDS instance is multi-AZ | `false` | no |
-| name | Name of security group | - | yes |
 | name | The DB name to create. If omitted, no database is created initially | `` | no |
+| name | Name of security group | - | yes |
 | network | The network | `<map>` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | `0` | no |
@@ -126,7 +127,7 @@ Stuff before terraform-docs
 | this_db_instance_status |  |
 | this_db_instance_username |  |
 | this_db_option_group_arn |  |
-| this_db_option_group_id |  |
+| this_db_option_group_id | # DB option group |
 | this_db_parameter_group_arn |  |
 | this_db_parameter_group_id |  |
 | this_db_subnet_group_arn |  |

--- a/tests/0.12/TEST-0.1.1.md
+++ b/tests/0.12/TEST-0.1.1.md
@@ -52,6 +52,7 @@ Stuff before terraform-docs
 | final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
+| ingress_cidr_blocks | Bzzzzz | list | `<list>` | no |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
@@ -70,8 +71,8 @@ Stuff before terraform-docs
 | monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
 | monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
 | multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
-| name | Name of security group | string | - | yes |
 | name | The DB name to create. If omitted, no database is created initially | string | `` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -126,7 +127,7 @@ Stuff before terraform-docs
 | this_db_instance_status | The RDS instance status |
 | this_db_instance_username | The master username for the database |
 | this_db_option_group_arn | The ARN of the db option group |
-| this_db_option_group_id | The db option group id |
+| this_db_option_group_id | DB option group |
 | this_db_parameter_group_arn | The ARN of the db parameter group |
 | this_db_parameter_group_id | The db parameter group id |
 | this_db_subnet_group_arn | The ARN of the db subnet group |

--- a/tests/0.12/TEST-0.2.0.md
+++ b/tests/0.12/TEST-0.2.0.md
@@ -52,6 +52,7 @@ Stuff before terraform-docs
 | final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
+| ingress_cidr_blocks | Bzzzzz | list | `<list>` | no |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
@@ -70,8 +71,8 @@ Stuff before terraform-docs
 | monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
 | monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
 | multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
-| name | Name of security group | string | - | yes |
 | name | The DB name to create. If omitted, no database is created initially | string | `` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -126,7 +127,7 @@ Stuff before terraform-docs
 | this_db_instance_status | The RDS instance status |
 | this_db_instance_username | The master username for the database |
 | this_db_option_group_arn | The ARN of the db option group |
-| this_db_option_group_id | The db option group id |
+| this_db_option_group_id | DB option group |
 | this_db_parameter_group_arn | The ARN of the db parameter group |
 | this_db_parameter_group_id | The db parameter group id |
 | this_db_subnet_group_arn | The ARN of the db subnet group |

--- a/tests/0.12/TEST-0.3.0.md
+++ b/tests/0.12/TEST-0.3.0.md
@@ -52,6 +52,7 @@ Stuff before terraform-docs
 | final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
+| ingress_cidr_blocks | Bzzzzz | list | `<list>` | no |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `<list>` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `<list>` | no |
@@ -70,8 +71,8 @@ Stuff before terraform-docs
 | monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
 | monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
 | multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
-| name | Name of security group | string | - | yes |
 | name | The DB name to create. If omitted, no database is created initially | string | `` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `<map>` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |
@@ -126,7 +127,7 @@ Stuff before terraform-docs
 | this_db_instance_status | The RDS instance status |
 | this_db_instance_username | The master username for the database |
 | this_db_option_group_arn | The ARN of the db option group |
-| this_db_option_group_id | The db option group id |
+| this_db_option_group_id | DB option group |
 | this_db_parameter_group_arn | The ARN of the db parameter group |
 | this_db_parameter_group_id | The db parameter group id |
 | this_db_subnet_group_arn | The ARN of the db subnet group |

--- a/tests/0.12/TEST-0.4.0.md
+++ b/tests/0.12/TEST-0.4.0.md
@@ -52,6 +52,7 @@ Stuff before terraform-docs
 | final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
+| ingress_cidr_blocks | Bzzzzz | list | `[ { "cidr_blocks": "10.0.0.0/32", "description": "SG", "from_port": 22, "protocol": "tcp", "to_port": 22 } ]` | no |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
@@ -70,8 +71,8 @@ Stuff before terraform-docs
 | monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
 | monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
 | multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
-| name | Name of security group | string | - | yes |
 | name | The DB name to create. If omitted, no database is created initially | string | `` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |

--- a/tests/0.12/TEST-0.4.5.md
+++ b/tests/0.12/TEST-0.4.5.md
@@ -51,6 +51,7 @@ Stuff before terraform-docs
 | final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
+| ingress_cidr_blocks | Bzzzzz | list | `[ { "cidr_blocks": "10.0.0.0/32", "description": "SG", "from_port": 22, "protocol": "tcp", "to_port": 22 } ]` | no |
 | ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |
@@ -69,8 +70,8 @@ Stuff before terraform-docs
 | monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
 | monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
 | multi_az | Specifies if the RDS instance is multi-AZ | bool | `false` | no |
-| name | Name of security group | string | - | yes |
 | name | The DB name to create. If omitted, no database is created initially | string | `` | no |
+| name | Name of security group | string | - | yes |
 | network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |
 | number_of_computed_egress_rules | Number of computed egress rules to create by name | number | `0` | no |
 | number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | number | `0` | no |

--- a/tests/0.12/TEST-0.5.0.md
+++ b/tests/0.12/TEST-0.5.0.md
@@ -58,6 +58,7 @@ Stuff before terraform-docs
 | family | The family of the DB parameter group | string | `` | no |
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `null` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |
+| ingress\_cidr\_blocks | Bzzzzz | list | `[ { "cidr_blocks": "10.0.0.0/32", "description": "SG", "from_port": 22, "protocol": "tcp", "to_port": 22 } ]` | no |
 | ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |

--- a/tests/0.12/TEST-0.6.0.md
+++ b/tests/0.12/TEST-0.6.0.md
@@ -58,6 +58,7 @@ Stuff before terraform-docs
 | family | The family of the DB parameter group | string | `""` | no |
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"null"` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `"false"` | no |
+| ingress\_cidr\_blocks | Bzzzzz | list | `[ { "cidr_blocks": "10.0.0.0/32", "description": "SG", "from_port": 22, "protocol": "tcp", "to_port": 22 } ]` | no |
 | ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list(string) | `[]` | no |

--- a/tests/0.12/TEST-latest.md
+++ b/tests/0.12/TEST-latest.md
@@ -58,6 +58,7 @@ Stuff before terraform-docs
 | family | The family of the DB parameter group | string | `""` | no |
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"null"` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management \(IAM\) accounts to database accounts is enabled | bool | `"false"` | no |
+| ingress\_cidr\_blocks | Bzzzzz | list | `[ { "cidr_blocks": "10.0.0.0/32", "description": "SG", "from_port": 22, "protocol": "tcp", "to_port": 22 } ]` | no |
 | ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list(string) | `[]` | no |
 | ingress\_prefix\_list\_ids | List of prefix list IDs \(for allowing access to VPC endpoints\) to use on all ingress rules | list(string) | `[]` | no |

--- a/tests/0.12/main.tf
+++ b/tests/0.12/main.tf
@@ -54,6 +54,35 @@ output "environment" {
 
 ###################################################################################################
 #
+# "description" key in type (https://github.com/antonbabenko/pre-commit-terraform/issues/65)
+#
+###################################################################################################
+variable "ingress_cidr_blocks" {
+  description = "Bzzzzz"
+  type = list(
+    object({
+      description = string
+      cidr_blocks = string
+      from_port   = number
+      to_port     = number
+      protocol    = string
+    })
+  )
+
+  default = [
+    {
+      description = "SG"
+      cidr_blocks = "10.0.0.0/32"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+    },
+  ]
+}
+
+
+###################################################################################################
+#
 # Quoted type (https://github.com/antonbabenko/pre-commit-terraform/issues/52)
 #
 ###################################################################################################


### PR DESCRIPTION
# Fix description key inside type

This PR fixes a when a key named `description` is inside the `type` block of a variable section:

```hcl
variable "ingress_cidr_blocks" {
  description = "Bzzzzz"
  type = list(
    object({
      description = string
      cidr_blocks = string
      from_port   = number
      to_port     = number
      protocol    = string
    })
  )

  default = [
    {
      description = "SG"
      cidr_blocks = "10.0.0.0/32"
      from_port   = 22
      to_port     = 22
      protocol    = "tcp"
    },
  ]
}
```

* Refs: https://github.com/antonbabenko/pre-commit-terraform/issues/65
* Refs: https://github.com/antonbabenko/pre-commit-terraform/issues/64

## Testing instructions

```
docker run --rm \
  -v $(pwd):/data \
  cytopia/terraform-docs:0.6.0-release-0.11 \
  terraform-docs-replace-012 \
    --sort-inputs-by-required \
    --with-aggregate-type-defaults md README.md
```